### PR TITLE
tweak destroy method

### DIFF
--- a/crfHeatMap.js
+++ b/crfHeatMap.js
@@ -2969,10 +2969,13 @@
 
     function onDestroy() {
         //remove stylesheet
-        document.getElementsByTagName('head')[0].lastChild.remove();
+        this.parent.style.remove();
 
         //clear container
-        d3.select(this.parent.element).html('');
+        d3
+            .select(this.parent.element)
+            .selectAll('*')
+            .remove();
     }
 
     function checkRequiredVariables() {

--- a/crfHeatMap.js
+++ b/crfHeatMap.js
@@ -2971,11 +2971,11 @@
         //remove stylesheet
         this.parent.style.remove();
 
-        //clear container
-        d3
-            .select(this.parent.element)
-            .selectAll('*')
-            .remove();
+        //clear container, removing one child node at a time (fastest method per https://jsperf.com/innerhtml-vs-removechild/37)
+        var node = d3.select(this.parent.element).node();
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
     }
 
     function checkRequiredVariables() {

--- a/src/onDestroy.js
+++ b/src/onDestroy.js
@@ -1,7 +1,10 @@
 export default function onDestroy() {
     //remove stylesheet
-    document.getElementsByTagName('head')[0].lastChild.remove();
+    this.parent.style.remove();
 
     //clear container
-    d3.select(this.parent.element).html('');
+    d3
+        .select(this.parent.element)
+        .selectAll('*')
+        .remove();
 }

--- a/src/onDestroy.js
+++ b/src/onDestroy.js
@@ -2,9 +2,7 @@ export default function onDestroy() {
     //remove stylesheet
     this.parent.style.remove();
 
-    //clear container
-    d3
-        .select(this.parent.element)
-        .selectAll('*')
-        .remove();
+    //clear container, removing one child node at a time (fastest method per https://jsperf.com/innerhtml-vs-removechild/37)
+    const node = d3.select(this.parent.element).node();
+    while (node.firstChild) node.removeChild(node.firstChild);
 }


### PR DESCRIPTION
since the stylesheet is attached to the crfHeatmap object, we can be a little more specific.  according to [this bench performance test](https://jsperf.com/innerhtml-vs-removechild/37) removing nodes iteratively is the fastest method to clear an element.